### PR TITLE
feat: optimize embed system and misc fixes

### DIFF
--- a/lib/src/commands/roles/reaction_roles.ts
+++ b/lib/src/commands/roles/reaction_roles.ts
@@ -9,6 +9,8 @@ import AuxdibotCommandInteraction from "../../util/templates/AuxdibotCommandInte
 import GuildAuxdibotCommandData from "../../util/types/commandData/GuildAuxdibotCommandData";
 import {LogType} from "../../util/types/Log";
 import emojiRegex from "emoji-regex";
+import createEmbedParameters from "../../util/functions/createEmbedParameters";
+import argumentsToEmbedParameters from "../../util/functions/argumentsToEmbedParameters";
 
 const reactionRolesCommand = <AuxdibotCommand>{
     data: new SlashCommandBuilder()
@@ -25,35 +27,14 @@ const reactionRolesCommand = <AuxdibotCommand>{
             .addStringOption(argBuilder => argBuilder.setName("title")
                 .setDescription("Title of the reaction roles."))
             )
-        .addSubcommand(builder => builder.setName("add_custom")
+        .addSubcommand(builder => createEmbedParameters(builder.setName("add_custom")
             .setDescription("Add a reaction role to the server.")
             .addChannelOption(argBuilder => argBuilder.setName("channel")
                 .setDescription("The channel to put the reaction role embed in.")
                 .setRequired(true))
             .addStringOption(argBuilder => argBuilder.setName("roles")
                 .setDescription("Space between emoji & role. (ex. [emoji] [role] [...emoji2] [...role2])")
-                .setRequired(true))
-            .addStringOption(option => option.setName("color")
-                .setDescription("The color of the Embed as a HEX color code.")
-                .setRequired(true))
-            .addStringOption(option => option.setName("title")
-                .setDescription("The title of the Embed.")
-                .setRequired(true))
-            .addStringOption(option => option.setName("description")
-                .setDescription("The description of the Embed. (Optional)"))
-            .addStringOption(option => option.setName("content")
-                .setDescription("The message content to send with the embed. (Optional)"))
-            .addStringOption(option => option.setName("author_text")
-                .setDescription("The author text of the Embed. (Optional)"))
-            .addStringOption(option => option.setName("fields")
-                .setDescription("Embed fields. \"Title|d|Description|s|Title|d|Description\" (Optional)"))
-            .addStringOption(option => option.setName("footer")
-                .setDescription("The footer text of the Embed. (Optional)"))
-            .addStringOption(option => option.setName("image_url")
-                .setDescription("The URL of the image for the Embed. (Optional)"))
-            .addStringOption(option => option.setName("thumbnail_url")
-                .setDescription("The URL of the thumbnail for the Embed. (Optional)"))
-        )
+                .setRequired(true))))
         .addSubcommand(builder => builder.setName("add_json")
             .setDescription("Add a reaction role to the server.")
             .addChannelOption(argBuilder => argBuilder.setName("channel")
@@ -69,29 +50,12 @@ const reactionRolesCommand = <AuxdibotCommand>{
         .addSubcommand(builder => builder.setName("remove").setDescription("Remove a reaction role from the server.")
             .addStringOption(argBuilder => argBuilder.setName("message_id").setDescription("The message id of the reaction role."))
             .addNumberOption(argBuilder => argBuilder.setName("index").setDescription("The index of the reaction role, which is the placement of the item on /reaction_roles list.")))
-        .addSubcommand(builder => builder.setName("edit").setDescription("Edit a reaction role embed on this server.")
+        .addSubcommand(builder => createEmbedParameters(builder.setName("edit").setDescription("Edit a reaction role embed on this server.")
             .addStringOption(argBuilder => argBuilder.setName("message_id").setDescription("The message id of the reaction role."))
             .addNumberOption(argBuilder => argBuilder.setName("index").setDescription("The index of the reaction role, which is the placement of the item on /reaction_roles list."))
-
-            .addStringOption(option => option.setName("color")
-                .setDescription("The color of the Embed as a HEX color code. (Optional)"))
-            .addStringOption(option => option.setName("title")
-                .setDescription("The title of the Embed. (Optional)"))
-            .addStringOption(option => option.setName("description")
-                .setDescription("The description of the Embed. (Optional)"))
-            .addStringOption(option => option.setName("author_text")
-                .setDescription("The author text of the Embed. (Optional)"))
-            .addStringOption(option => option.setName("fields")
-                .setDescription("Embed fields. ex. \"Title|d|Description|s|Title|d|Description\" (Optional)"))
-            .addStringOption(option => option.setName("footer")
-                .setDescription("The footer text of the Embed. (Optional)"))
-            .addStringOption(option => option.setName("image_url")
-                .setDescription("The URL of the image for the Embed. (Optional)"))
-            .addStringOption(option => option.setName("thumbnail_url")
-                .setDescription("The URL of the thumbnail for the Embed. (Optional)"))
             .addStringOption(argBuilder => argBuilder.setName("json")
                 .setDescription("The JSON for the Discord Embed attached to the reaction role. (overrides embed parameters)"))
-            )
+            ))
         .addSubcommand(builder => builder.setName("list").setDescription("List the reaction roles on this server.")),
     info: {
         help: {
@@ -173,28 +137,16 @@ const reactionRolesCommand = <AuxdibotCommand>{
                     commandCategory: "Roles",
                     name: "/reaction_roles add_custom",
                     description: "Add a reaction role to the server with custom Embed parameters.",
-                    usageExample: "/reaction_roles add_custom (channel) (roles) (color) (title) [author_text] [description] [fields (split title and description with `\"|d|\"``, and seperate fields with `\"|s|\"`)] [footer] [image url] [thumbnail url]"
+                    usageExample: "/reaction_roles add_custom (channel) (roles) [content] [color] [title] [title url] [author] [author icon url] [author url] [description] [fields (split title and description with `\"|d|\"``, and seperate fields with `\"|s|\"`)] [footer] [footer icon url] [image url] [thumbnail url]"
                 },
                 permission: "rr.add.custom"
             },
             async execute(interaction: AuxdibotCommandInteraction<GuildAuxdibotCommandData>) {
                 if (!interaction.data) return;
                 let channel = interaction.options.getChannel("channel"), roles = interaction.options.getString("roles"),
-                    color = interaction.options.getString("color"),
-                    title = interaction.options.getString("title")?.replace(/\\n/g, "\n"),
-                    description = interaction.options.getString("description")?.replace(/\\n/g, "\n") || null,
-                    content = interaction.options.getString("content")?.replace(/\\n/g, "\n") || "",
-                    author_text = interaction.options.getString("author_text")?.replace(/\\n/g, "\n") || null,
-                    fields = interaction.options.getString("fields")?.replace(/\\n/g, "\n") || null,
-                    footer = interaction.options.getString("footer")?.replace(/\\n/g, "\n") || null,
-                    image_url = interaction.options.getString("image_url") || null,
-                    thumbnail_url = interaction.options.getString("thumbnail_url") || null;
+                    content = interaction.options.getString("content")?.replace(/\\n/g, "\n") || "";
+                
                 let data = await interaction.data.guildData.fetchData();
-                if (!color || !/(#|)[0-9a-fA-F]{6}/.test(color)) {
-                    let error = Embeds.ERROR_EMBED.toJSON();
-                    error.description = "Invalid hex color code!";
-                    return await interaction.reply({ embeds: [Embeds.ERROR_EMBED.toJSON()] })
-                }
                 if (!channel || !roles) return;
                 if (channel.type != ChannelType.GuildText) {
                     let errorEmbed = Embeds.ERROR_EMBED.toJSON();
@@ -224,23 +176,9 @@ const reactionRolesCommand = <AuxdibotCommand>{
                     errorEmbed.description = "No reactions and roles found! Please use spaces between reactions and roles. (ex. [emoji] [role] [emoji2] [role2] ...)";
                     return await interaction.reply({ embeds: [errorEmbed] });
                 }
-
-                let parameters = <EmbedParameters>{
-                    color,
-                    title,
-                    description,
-                    author_text,
-                    fields: fields ? fields.split("|s|").map((field) => (<EmbedField>{ name: field.split("|d|")[0].replace(/\\n/g, "\n"), value: field.split("|d|")[1].replace(/\\n/g, "\n") })) : undefined,
-                    footer,
-                    thumbnail_url,
-                    image_url
-                };
-                let message = await channel.send({ content: content, embeds: [toAPIEmbed(JSON.parse(await parsePlaceholders(JSON.stringify(parameters), interaction.data.guild, interaction.member as GuildMember | undefined))) as APIEmbed] }).catch(() => undefined);
-                if (!message) {
-                    let embed = Embeds.ERROR_EMBED.toJSON();
-                    embed.description = `There was an error sending that embed!`;
-                    return await interaction.reply({ embeds: [embed] });
-                }
+                try {
+                let parameters = argumentsToEmbedParameters(interaction);
+                let message = await channel.send({ content: content, embeds: [toAPIEmbed(JSON.parse(await parsePlaceholders(JSON.stringify(parameters), interaction.data.guild, interaction.member as GuildMember | undefined))) as APIEmbed] });
                 reactionsAndRoles.forEach((item) => message ? message.react(item.emoji) : undefined);
                 data.addReactionRole({ message_id: message.id, reactions: reactionsAndRoles });
                 let successEmbed = Embeds.SUCCESS_EMBED.toJSON();
@@ -253,6 +191,11 @@ const reactionRolesCommand = <AuxdibotCommand>{
                     date_unix: Date.now()
                 })
                 return await interaction.reply({ embeds: [successEmbed] });
+                } catch (x) {
+                    let embed = Embeds.ERROR_EMBED.toJSON();
+                    embed.description = `There was an error sending that embed!`;
+                    return await interaction.reply({ embeds: [embed] });
+                }
             }
         },
         {
@@ -393,7 +336,7 @@ const reactionRolesCommand = <AuxdibotCommand>{
                     commandCategory: "Roles",
                     name: "/reaction_roles edit",
                     description: "Edit a reaction role on this server.",
-                    usageExample: "/reaction_roles edit [message_id] [index] (roles) [json, overrides embed parameters] [color] [title] [author_text] [description] [fields (split title and description with `\"|d|\"``, and seperate fields with `\"|s|\"`)] [footer] [image url] [thumbnail url]"
+                    usageExample: "/reaction_roles edit [message_id] [index] (roles) [json, overrides embed parameters] [content] [color] [title] [title url] [author] [author icon url] [author url] [description] [fields (split title and description with `\"|d|\"``, and seperate fields with `\"|s|\"`)] [footer] [footer icon url] [image url] [thumbnail url]"
                 },
                 permission: "rr.edit"
             },
@@ -402,14 +345,7 @@ const reactionRolesCommand = <AuxdibotCommand>{
                 let message_id = interaction.options.getString("message_id"),
                     index = interaction.options.getNumber("index"),
                     json = interaction.options.getString("json"),
-                    color = interaction.options.getString("color"),
-                    title = interaction.options.getString("title")?.replace(/\\n/g, "\n"),
-                    description = interaction.options.getString("description")?.replace(/\\n/g, "\n") || null,
-                    author_text = interaction.options.getString("author_text")?.replace(/\\n/g, "\n") || null,
-                    fields = interaction.options.getString("fields")?.replace(/\\n/g, "\n") || null,
-                    footer = interaction.options.getString("footer")?.replace(/\\n/g, "\n") || null,
-                    image_url = interaction.options.getString("image_url") || null,
-                    thumbnail_url = interaction.options.getString("thumbnail_url") || null;
+                    content = interaction.options.getString("content");
                 let data = await interaction.data.guildData.fetchData();
                 if (!message_id && !index) {
                     let embed = Embeds.ERROR_EMBED.toJSON();
@@ -430,7 +366,7 @@ const reactionRolesCommand = <AuxdibotCommand>{
                     return await interaction.reply({ embeds: [embed] });
                 }
                 if (json) {
-                    let messageEdit = await message.edit({ embeds: [JSON.parse(await parsePlaceholders(json || "", interaction.data.guild, interaction.member as GuildMember | undefined)) as APIEmbed]}).catch(() => undefined)
+                    let messageEdit = await message.edit({ ...(content ? {content} : {}), embeds: [JSON.parse(await parsePlaceholders(json || "", interaction.data.guild, interaction.member as GuildMember | undefined)) as APIEmbed]}).catch(() => undefined)
                     if (!messageEdit) {
                         let embed = Embeds.ERROR_EMBED.toJSON();
                         embed.description = `There was an error sending that embed!`;
@@ -447,23 +383,10 @@ const reactionRolesCommand = <AuxdibotCommand>{
                     })
                     return await interaction.reply({ embeds: [successEmbed] });
                 }
-                if (color && title) {
-                    if (!color || !/(#|)[0-9a-fA-F]{6}/.test(color)) {
-                        let error = Embeds.ERROR_EMBED.toJSON();
-                        error.description = "Invalid hex color code!";
-                        return await interaction.reply({ embeds: [Embeds.ERROR_EMBED.toJSON()] })
-                    }
-                    let parameters = <EmbedParameters>{
-                        color,
-                        title,
-                        description,
-                        author_text,
-                        fields: fields ? fields.split("|s|").map((field) => (<EmbedField>{ name: field.split("|d|")[0].replace(/\\n/g, "\n"), value: field.split("|d|")[1].replace(/\\n/g, "\n") })) : undefined,
-                        footer,
-                        thumbnail_url,
-                        image_url
-                    };
-                    let messageEdit = await message.edit({ embeds: [toAPIEmbed(JSON.parse(await parsePlaceholders(JSON.stringify(parameters), interaction.data.guild, interaction.member as GuildMember | undefined))) as APIEmbed] }).catch(() => undefined);
+
+                try {
+                    let parameters = argumentsToEmbedParameters(interaction);
+                    let messageEdit = await message.edit({ ...(content ? {content} : {}), embeds: [toAPIEmbed(JSON.parse(await parsePlaceholders(JSON.stringify(parameters), interaction.data.guild, interaction.member as GuildMember | undefined))) as APIEmbed] }).catch(() => undefined);
                     if (!messageEdit) {
                         let embed = Embeds.ERROR_EMBED.toJSON();
                         embed.description = `There was an error sending that embed!`;
@@ -479,10 +402,12 @@ const reactionRolesCommand = <AuxdibotCommand>{
                         date_unix: Date.now()
                     })
                     return await interaction.reply({ embeds: [successEmbed] });
+                } catch (x) {
+                    let embed = Embeds.ERROR_EMBED.toJSON();
+                    embed.description = `There was an error creating that embed!`;
+                    return await interaction.reply({ embeds: [embed] });
                 }
-                let embed = Embeds.ERROR_EMBED.toJSON();
-                embed.description = `Nothing happened.`;
-                return await interaction.reply({ embeds: [embed] });
+                
             }
         }],
     async execute() {

--- a/lib/src/commands/settings/join_dm.ts
+++ b/lib/src/commands/settings/join_dm.ts
@@ -7,97 +7,67 @@ import EmbedParameters, {toAPIEmbed} from "../../util/types/EmbedParameters";
 import parsePlaceholders from "../../util/functions/parsePlaceholder";
 import AuxdibotCommandInteraction from "../../util/templates/AuxdibotCommandInteraction";
 import GuildAuxdibotCommandData from "../../util/types/commandData/GuildAuxdibotCommandData";
+import createEmbedParameters from "../../util/functions/createEmbedParameters";
+import argumentsToEmbedParameters from "../../util/functions/argumentsToEmbedParameters";
 
 const joinCommand = <AuxdibotCommand>{
     data: new SlashCommandBuilder()
         .setName('join_dm')
         .setDescription('Change settings for join DM messages on the server.')
-        .addSubcommand(builder => builder.setName('embed').setDescription('Display an embed (With placeholders)!')
-            .addStringOption(option => option.setName("color")
-                .setDescription("The color of the Embed as a HEX color code.")
-                .setRequired(true))
-            .addStringOption(option => option.setName("title")
-                .setDescription("The title of the Embed.")
-                .setRequired(true))
-            .addStringOption(option => option.setName("description")
-                .setDescription("The description of the Embed. (Optional)"))
-            .addStringOption(option => option.setName("author_text")
-                .setDescription("The author text of the Embed. (Optional)"))
-            .addStringOption(option => option.setName("fields")
-                .setDescription("Embed fields. \"Title|d|Description|s|Title|d|Description\" (Optional)"))
-            .addStringOption(option => option.setName("footer")
-                .setDescription("The footer text of the Embed. (Optional)"))
-            .addStringOption(option => option.setName("image_url")
-                .setDescription("The URL of the image for the Embed. (Optional)"))
-            .addStringOption(option => option.setName("thumbnail_url")
-                .setDescription("The URL of the thumbnail for the Embed. (Optional)")))
+        .addSubcommand(builder => createEmbedParameters(builder.setName('message').setDescription('Display an embed (With placeholders)!')))
         .addSubcommand(builder => builder.setName('embed_json').setDescription('Display some JSON as an embed (With placeholders)!')
             .addStringOption(option => option.setName("json")
             .setDescription("The JSON data to use for creating the Discord Embed.")
             .setRequired(true)))
-        .addSubcommand(builder => builder.setName("text").setDescription("Show text (With placeholders!)")
-            .addStringOption(option => option.setName("text")
-                .setDescription("The text to use when a member joins the server")))
         .addSubcommand(builder => builder.setName('preview').setDescription('Preview the join embed.')),
     info: {
         help: {
             commandCategory: "Settings",
             name: "/join_dm",
             description: "Change settings for join DM messages on the server. (Placeholders are supported. Do /placeholders for a list of placeholders.)",
-            usageExample: "/join_dm (embed|embed_json|text|preview)"
+            usageExample: "/join_dm (message|embed_json|preview)"
         },
         permission: "settings.joindm"
     },
     subcommands: [{
-        name: "embed",
+        name: "message",
         info: {
             help: {
                 commandCategory: "Settings",
-                name: "/join_dm embed (color) (title) [author_text] [description] [fields (split title and description with `\"|d|\"``, and seperate fields with `\"|s|\"`)] [footer] [image url] [thumbnail url]",
-                description: "Add an embed to the join DM message. (Placeholders are supported. Do /placeholders for a list of placeholders.)",
-                usageExample: "/join_dm embed"
+                name: "/join_dm message",
+                description: "Set the join DM message. (Placeholders are supported. Do /placeholders for a list of placeholders.)",
+                usageExample: "/join_dm message [content] [color] [title] [title url] [author] [author icon url] [author url] [description] [fields (split title and description with `\"|d|\"``, and seperate fields with `\"|s|\"`)] [footer] [footer icon url] [image url] [thumbnail url]"
             },
-            permission: "settings.joindm.embed"
+            permission: "settings.joindm.message"
         },
         async execute(interaction: AuxdibotCommandInteraction<GuildAuxdibotCommandData>) {
             if (!interaction.data) return;
-            let color = interaction.options.getString("color"),
-                title = interaction.options.getString("title")?.replace(/\\n/g, "\n"),
-                description = interaction.options.getString("description")?.replace(/\\n/g, "\n") || null,
-                author_text = interaction.options.getString("author_text")?.replace(/\\n/g, "\n") || null,
-                fields = interaction.options.getString("fields")?.replace(/\\n/g, "\n") || null,
-                footer = interaction.options.getString("footer")?.replace(/\\n/g, "\n") || null,
-                image_url = interaction.options.getString("image_url") || null,
-                thumbnail_url = interaction.options.getString("thumbnail_url") || null;
             let settings = await interaction.data.guildData.fetchSettings();
-            if (!color || !/(#|)[0-9a-fA-F]{6}/.test(color)) {
-                let error = Embeds.ERROR_EMBED.toJSON();
-                error.description = "Invalid hex color code!";
-                return await interaction.reply({ embeds: [Embeds.ERROR_EMBED.toJSON()] })
+            let content = interaction.options.getString("content");
+            let parameters = argumentsToEmbedParameters(interaction);
+            try {
+                settings.setJoinDMEmbed(toAPIEmbed(parameters));
+                if (content) {
+                    settings.setJoinDMText(content);
+                }
+                await settings.save();
+                let embed = Embeds.SUCCESS_EMBED.toJSON();
+                embed.title = "Success!";
+                embed.description = `Set the join DM embed.`;
+                await interaction.reply({ embeds: [embed] })
+            } catch (x) {
+                let embed = Embeds.ERROR_EMBED.toJSON();
+                embed.description = "Couldn't make that embed!";
+                return await interaction.reply({ embeds: [embed] });
             }
-            let parameters = <EmbedParameters>{
-                color,
-                title,
-                description,
-                author_text,
-                fields: fields ? fields.split("|s|").map((field) => (<EmbedField>{ name: field.split("|d|")[0].replace(/\\n/g, "\n"), value: field.split("|d|")[1].replace(/\\n/g, "\n") })) : undefined,
-                footer,
-                thumbnail_url,
-                image_url
-            };
-
-            settings.setJoinDMEmbed(toAPIEmbed(parameters));
-            let embed = Embeds.SUCCESS_EMBED.toJSON();
-            embed.title = "Success!";
-            embed.description = `Set the join DM embed.`;
+            
 
             if (interaction.channel && (interaction.channel as Channel).isTextBased()) {
                 try {
                     let channel = (interaction.channel) as TextChannel;
-                    await channel.send({ content: "Here's a preview of the new join DM embed!", embeds: [JSON.parse(await parsePlaceholders(JSON.stringify(settings.join_dm_embed), interaction.data.guild, interaction.data.member)) as APIEmbed] });
+                    await channel.send({ content: `Here's a preview of the new join DM embed!\n${settings.join_dm_text || ""}`, embeds: [JSON.parse(await parsePlaceholders(JSON.stringify(settings.join_dm_embed), interaction.data.guild, interaction.data.member)) as APIEmbed] });
                 } catch (x) { }
             }
-            return await interaction.reply({ embeds: [embed] });
         }
     },
         {
@@ -105,11 +75,11 @@ const joinCommand = <AuxdibotCommand>{
             info: {
                 help: {
                     commandCategory: "Settings",
-                    name: "/joindm embed_json (json)",
+                    name: "/join_dm embed_json",
                     description: "Add an embed to the join DM message using custom JSON. (Placeholders are supported. Do /placeholders for a list of placeholders.)",
-                    usageExample: "/joindm embed_json"
+                    usageExample: "/join_dm embed_json (json)"
                 },
-                permission: "settings.joindm.embed.json"
+                permission: "settings.joindm.embed_json"
             },
             async execute(interaction: AuxdibotCommandInteraction<GuildAuxdibotCommandData>) {
                 if (!interaction.data) return;
@@ -123,6 +93,7 @@ const joinCommand = <AuxdibotCommand>{
                     return await interaction.reply({ embeds: [error] });
                 }
                 settings.setJoinDMEmbed(jsonEmbed);
+                await settings.save();
                 let embed = Embeds.SUCCESS_EMBED.toJSON();
                 embed.title = "Success!";
                 embed.description = `Set the join DM embed.`;
@@ -133,28 +104,6 @@ const joinCommand = <AuxdibotCommand>{
                         await channel.send({ content: "Here's a preview of the new join DM embed!", embeds: [JSON.parse(await parsePlaceholders(JSON.stringify(settings.join_dm_embed), interaction.data.guild, interaction.data.member)) as APIEmbed] });
                     } catch (x) { }
                 }
-                return await interaction.reply({ embeds: [embed] });
-            }
-        },
-        {
-            name: "text",
-            info: {
-                help: {
-                    commandCategory: "Settings",
-                    name: "/join_dm text (text)",
-                    description: "Add text to the join DM message.",
-                    usageExample: "/join_dm text"
-                },
-                permission: "settings.joindm.text"
-            },
-            async execute(interaction: AuxdibotCommandInteraction<GuildAuxdibotCommandData>) {
-                if (!interaction.data) return;
-                let text = interaction.options.getString('text') || "";
-                let settings = await interaction.data.guildData.fetchSettings();
-                settings.setJoinDMText(text);
-                let embed = Embeds.SUCCESS_EMBED.toJSON();
-                embed.title = "Success!";
-                embed.description = `Set the join message text to "${settings.join_dm_text}".`;
                 return await interaction.reply({ embeds: [embed] });
             }
         },

--- a/lib/src/commands/settings/leave.ts
+++ b/lib/src/commands/settings/leave.ts
@@ -8,96 +8,66 @@ import parsePlaceholders from "../../util/functions/parsePlaceholder";
 import EmbedParameters, {toAPIEmbed} from "../../util/types/EmbedParameters";
 import AuxdibotCommandInteraction from "../../util/templates/AuxdibotCommandInteraction";
 import GuildAuxdibotCommandData from "../../util/types/commandData/GuildAuxdibotCommandData";
+import createEmbedParameters from "../../util/functions/createEmbedParameters";
+import argumentsToEmbedParameters from "../../util/functions/argumentsToEmbedParameters";
 
 const leaveCommand = <AuxdibotCommand>{
     data: new SlashCommandBuilder()
         .setName('leave')
         .setDescription('Change settings for leave messages on the server.')
-        .addSubcommand(builder => builder.setName('embed').setDescription('Display an embed (With placeholders)!')
-            .addStringOption(option => option.setName("color")
-                .setDescription("The color of the Embed as a HEX color code.")
-                .setRequired(true))
-            .addStringOption(option => option.setName("title")
-                .setDescription("The title of the Embed.")
-                .setRequired(true))
-            .addStringOption(option => option.setName("description")
-                .setDescription("The description of the Embed. (Optional)"))
-            .addStringOption(option => option.setName("author_text")
-                .setDescription("The author text of the Embed. (Optional)"))
-            .addStringOption(option => option.setName("fields")
-                .setDescription("Embed fields. \"Title|d|Description|s|Title|d|Description\" (Optional)"))
-            .addStringOption(option => option.setName("footer")
-                .setDescription("The footer text of the Embed. (Optional)"))
-            .addStringOption(option => option.setName("image_url")
-                .setDescription("The URL of the image for the Embed. (Optional)"))
-            .addStringOption(option => option.setName("thumbnail_url")
-                .setDescription("The URL of the thumbnail for the Embed. (Optional)")))
+        .addSubcommand(builder => createEmbedParameters(builder.setName('message').setDescription('Display an embed (With placeholders)!')))
         .addSubcommand(builder => builder.setName('embed_json').setDescription('Display some JSON as an embed (With placeholders)!')
             .addStringOption(option => option.setName("json")
             .setDescription("The JSON data to use for creating the Discord Embed.")
             .setRequired(true)))
-        .addSubcommand(builder => builder.setName("text").setDescription("Show text (With placeholders!)")
-            .addStringOption(option => option.setName("text")
-                .setDescription("The text to use when a member leaves the server")))
         .addSubcommand(builder => builder.setName('preview').setDescription('Preview the leave embed.')),
     info: {
         help: {
             commandCategory: "Settings",
             name: "/leave",
             description: "Change settings for leave messages on the server. (Placeholders are supported. Do /placeholders for a list of placeholders.)",
-            usageExample: "/leave (embed|embed_json|text)"
+            usageExample: "/leave (message|embed_json|preview)"
         },
         permission: "settings.leave"
     },
     subcommands: [{
-        name: "embed",
+        name: "message",
         info: {
             help: {
                 commandCategory: "Settings",
-                name: "/leave embed (color) (title) [author_text] [description] [fields (split title and description with `\"|d|\"``, and seperate fields with `\"|s|\"`)] [footer] [image url] [thumbnail url]",
-                description: "Add an embed to the leave message. (Placeholders are supported. Do /placeholders for a list of placeholders.)",
-                usageExample: "/leave embed"
+                name: "/leave message",
+                description: "Set the leave message. (Placeholders are supported. Do /placeholders for a list of placeholders.)",
+                usageExample: "/leave message (color) (title) [author_text] [description] [fields (split title and description with `\"|d|\"``, and seperate fields with `\"|s|\"`)] [footer] [image url] [thumbnail url]"
             },
-            permission: "settings.leave.embed"
+            permission: "settings.leave.message"
         },
         async execute(interaction: AuxdibotCommandInteraction<GuildAuxdibotCommandData>) {
             if (!interaction.data) return;
             let settings = await interaction.data.guildData.fetchSettings();
-            let color = interaction.options.getString("color"),
-                title = interaction.options.getString("title")?.replace(/\\n/g, "\n"),
-                description = interaction.options.getString("description")?.replace(/\\n/g, "\n") || null,
-                author_text = interaction.options.getString("author_text")?.replace(/\\n/g, "\n") || null,
-                fields = interaction.options.getString("fields")?.replace(/\\n/g, "\n") || null,
-                footer = interaction.options.getString("footer")?.replace(/\\n/g, "\n") || null,
-                image_url = interaction.options.getString("image_url") || null,
-                thumbnail_url = interaction.options.getString("thumbnail_url") || null;
-            if (!color || !/(#|)[0-9a-fA-F]{6}/.test(color)) {
-                let error = Embeds.ERROR_EMBED.toJSON();
-                error.description = "Invalid hex color code!";
-                return await interaction.reply({ embeds: [Embeds.ERROR_EMBED.toJSON()] })
+            let content = interaction.options.getString("content");
+            let parameters = argumentsToEmbedParameters(interaction);
+            try {
+                settings.setLeaveEmbed(toAPIEmbed(parameters));
+                if (content) {
+                    settings.setLeaveText(content);
+                }
+                await settings.save();
+                let embed = Embeds.SUCCESS_EMBED.toJSON();
+                embed.title = "Success!";
+                embed.description = `Set the leave embed.`;
+                await interaction.reply({ embeds: [embed] });
+            } catch (x) {
+                let embed = Embeds.ERROR_EMBED.toJSON();
+                embed.description = "Couldn't make that embed!";
+                return await interaction.reply({ embeds: [embed] });
             }
-            let parameters = <EmbedParameters>{
-                color,
-                title,
-                description,
-                author_text,
-                fields: fields ? fields.split("|s|").map((field) => (<EmbedField>{ name: field.split("|d|")[0].replace(/\\n/g, "\n"), value: field.split("|d|")[1].replace(/\\n/g, "\n") })) : undefined,
-                footer,
-                thumbnail_url,
-                image_url
-            };
-            settings.setLeaveEmbed(toAPIEmbed(parameters));
-            let embed = Embeds.SUCCESS_EMBED.toJSON();
-            embed.title = "Success!";
-            embed.description = `Set the leave embed.`;
-
             if (interaction.channel && (interaction.channel as Channel).isTextBased()) {
                 try {
                     let channel = (interaction.channel) as TextChannel;
                     await channel.send({ content: "Here's a preview of the new leave embed!", embeds: [JSON.parse(await parsePlaceholders(JSON.stringify(settings.leave_embed), interaction.data.guild, interaction.data.member)) as APIEmbed] });
                 } catch (x) { }
             }
-            return await interaction.reply({ embeds: [embed] });
+            return; 
         }
     },
         {
@@ -105,11 +75,11 @@ const leaveCommand = <AuxdibotCommand>{
             info: {
                 help: {
                     commandCategory: "Settings",
-                    name: "/leave embed_json (json)",
+                    name: "/leave embed_json",
                     description: "Add an embed to the join message using custom JSON. (Placeholders are supported. Do /placeholders for a list of placeholders.)",
-                    usageExample: "/leave embed_json"
+                    usageExample: "/leave embed_json (json)"
                 },
-                permission: "settings.leave.embed.json"
+                permission: "settings.leave.embed_json"
             },
             async execute(interaction: AuxdibotCommandInteraction<GuildAuxdibotCommandData>) {
                 if (!interaction.data) return;
@@ -123,6 +93,7 @@ const leaveCommand = <AuxdibotCommand>{
                     return await interaction.reply({ embeds: [error] });
                 }
                 settings.setLeaveEmbed(jsonEmbed);
+                await settings.save();
                 let embed = Embeds.SUCCESS_EMBED.toJSON();
                 embed.title = "Success!";
                 embed.description = `Set the leave embed.`;
@@ -133,28 +104,6 @@ const leaveCommand = <AuxdibotCommand>{
                         await channel.send({ content: "Here's a preview of the new leave embed!", embeds: [JSON.parse(await parsePlaceholders(JSON.stringify(settings.leave_embed), interaction.data.guild, interaction.data.member)) as APIEmbed] });
                     } catch (x) { }
                 }
-                return await interaction.reply({ embeds: [embed] });
-            }
-        },
-        {
-            name: "text",
-            info: {
-                help: {
-                    commandCategory: "Settings",
-                    name: "/leave text (text)",
-                    description: "Add text to the join message.",
-                    usageExample: "/leave text"
-                },
-                permission: "settings.leave.text"
-            },
-            async execute(interaction: AuxdibotCommandInteraction<GuildAuxdibotCommandData>) {
-                if (!interaction.data) return;
-                let text = interaction.options.getString('text') || "";
-                let settings = await interaction.data.guildData.fetchSettings();
-                settings.setLeaveText(text);
-                let embed = Embeds.SUCCESS_EMBED.toJSON();
-                embed.title = "Success!";
-                embed.description = `Set the leave message text to "${settings.leave_text}".`;
                 return await interaction.reply({ embeds: [embed] });
             }
         },

--- a/lib/src/modules/discord.ts
+++ b/lib/src/modules/discord.ts
@@ -43,6 +43,12 @@ export class AuxdibotClient {
 
         client.commands = new Collection();
         client.buttons = new Collection();
+        client.getMembers = function() {
+            return this.guilds.cache.reduce((acc, guild) => {
+                if (!guild.available) return acc;
+                return (acc+(guild.memberCount || 0));
+            } , 0);
+        }
         /********************************************************************************/
         // Declare commands
 
@@ -130,7 +136,7 @@ export class AuxdibotClient {
                 client.user.setPresence({
                     activities: [{
                         type: ActivityType.Watching,
-                        name: `${client.guilds.cache.size} servers! (NEW! Roles)`
+                        name: `${client.guilds.cache.size} servers | ${client.getMembers ? client.getMembers() : "0"} members`
                     }]
                 })
             }
@@ -176,7 +182,7 @@ export const updateDiscordStatus = async () => {
     if (awaitClient.user) return awaitClient.user.setPresence({
         activities: [{
             type: ActivityType.Watching,
-            name: `${awaitClient.guilds.cache.size} servers! (NEW! Roles)`
+            name: `${awaitClient.guilds.cache.size} servers | ${awaitClient.getMembers ? awaitClient.getMembers() : "0"} members`
         }]
     });
     return false;

--- a/lib/src/mongo/model/server/ServerSettings.ts
+++ b/lib/src/mongo/model/server/ServerSettings.ts
@@ -104,32 +104,26 @@ ServerSettingsSchema.method('setJoinLeaveChannel', function(join_leave_channel_i
 });
 ServerSettingsSchema.method('setJoinEmbed', function(join_embed: APIEmbed) {
     this.join_embed = join_embed;
-    this.save();
     return true;
 });
 ServerSettingsSchema.method('setJoinDMEmbed', function(join_dm_embed: APIEmbed) {
     this.join_dm_embed = join_dm_embed;
-    this.save();
     return true;
 });
 ServerSettingsSchema.method('setLeaveEmbed', function(leave_embed: APIEmbed) {
     this.leave_embed = leave_embed;
-    this.save();
     return true;
 });
 ServerSettingsSchema.method('setJoinText', function(join_text: String) {
     this.join_text = join_text;
-    this.save();
     return true;
 });
 ServerSettingsSchema.method('setJoinDMText', function(join_dm_text: String) {
     this.join_dm_text = join_dm_text;
-    this.save();
     return true;
 });
 ServerSettingsSchema.method('setLeaveText', function(leave_text: String) {
     this.leave_text = leave_text;
-    this.save();
     return true;
 });
 ServerSettingsSchema.method("addSuggestionsReaction", function(reaction: ISuggestionReaction) {

--- a/lib/src/util/functions/argumentsToEmbedParameters.ts
+++ b/lib/src/util/functions/argumentsToEmbedParameters.ts
@@ -1,0 +1,33 @@
+import { EmbedField } from "discord.js";
+import AuxdibotCommandInteraction from "../templates/AuxdibotCommandInteraction";
+import EmbedParameters from "../types/EmbedParameters";
+import GuildAuxdibotCommandData from "../types/commandData/GuildAuxdibotCommandData";
+
+export default function argumentsToEmbedParameters(interaction: AuxdibotCommandInteraction<GuildAuxdibotCommandData>) {
+    let color = interaction.options.getString("color") || null,
+            title = interaction.options.getString("title")?.replace(/\\n/g, "\n") || null,
+            title_url = interaction.options.getString("title_url") || null,
+            description = interaction.options.getString("description")?.replace(/\\n/g, "\n") || null,
+            author_text = interaction.options.getString("author_text")?.replace(/\\n/g, "\n") || null,
+            author_url = interaction.options.getString("author_url") || null,
+            author_icon = interaction.options.getString("author_icon_url") || null,
+            fields = interaction.options.getString("fields")?.replace(/\\n/g, "\n") || null,
+            footer_text = interaction.options.getString("footer_text")?.replace(/\\n/g, "\n") || null,
+            footer_icon = interaction.options.getString("footer_icon_url") || null,
+            image_url = interaction.options.getString("image_url") || null,
+            thumbnail_url = interaction.options.getString("thumbnail_url") || null;
+    return <EmbedParameters>{
+        color,
+        title,
+        title_url,
+        description,
+        author_text,
+        author_url,
+        author_icon,
+        fields: fields ? fields.split("|s|").map((field) => (<EmbedField>{ name: field.split("|d|")[0].replace(/\\n/g, "\n"), value: field.split("|d|")[1].replace(/\\n/g, "\n") })) : undefined,
+        footer_text,
+        footer_icon,
+        thumbnail_url,
+        image_url
+    };
+}

--- a/lib/src/util/functions/createEmbedParameters.ts
+++ b/lib/src/util/functions/createEmbedParameters.ts
@@ -1,0 +1,31 @@
+import { SlashCommandSubcommandBuilder } from "discord.js";
+
+export default function createEmbedParameters(builder: SlashCommandSubcommandBuilder): SlashCommandSubcommandBuilder  {
+    return builder.addStringOption(option => option.setName("color")
+    .setDescription("The color of the Embed as a HEX color code. (Optional)"))
+.addStringOption(option => option.setName("title")
+    .setDescription("The title of the Embed. (Optional)"))
+.addStringOption(option => option.setName("title_url")
+    .setDescription("The URL for Title of the Embed. (Optional)"))
+.addStringOption(option => option.setName("content")
+    .setDescription("The message content to send with the embed. (Optional)"))
+.addStringOption(option => option.setName("description")
+    .setDescription("The description of the Embed. (Optional)"))
+.addStringOption(option => option.setName("author_text")
+    .setDescription("The author text of the Embed. (Optional)"))
+.addStringOption(option => option.setName("author_url")
+    .setDescription("The URL for the Author of the Embed. (Optional)"))
+.addStringOption(option => option.setName("author_icon_url")
+    .setDescription("The URL of the footer icon for the Embed. (Optional)"))
+.addStringOption(option => option.setName("fields")
+    .setDescription("Embed fields. \"Title|d|Description|s|Title|d|Description\" (Optional)"))
+.addStringOption(option => option.setName("footer_text")
+    .setDescription("The footer text of the Embed. (Optional)"))
+.addStringOption(option => option.setName("footer_icon_url")
+    .setDescription("The URL of the footer icon for the Embed. (Optional)"))
+.addStringOption(option => option.setName("image_url")
+    .setDescription("The URL of the image for the Embed. (Optional)"))
+.addStringOption(option => option.setName("thumbnail_url")
+    .setDescription("The URL of the thumbnail for the Embed. (Optional)"))
+
+}

--- a/lib/src/util/templates/IAuxdibot.ts
+++ b/lib/src/util/templates/IAuxdibot.ts
@@ -5,4 +5,5 @@ import AuxdibotButton from "../types/AuxdibotButton";
 export interface IAuxdibot extends Client {
     commands?: Collection<string, AuxdibotCommand>;
     buttons?: Collection<string, AuxdibotButton>;
+    getMembers?(): number;
 }

--- a/lib/src/util/types/EmbedParameters.ts
+++ b/lib/src/util/types/EmbedParameters.ts
@@ -1,20 +1,31 @@
 import {APIEmbed, EmbedBuilder, EmbedField} from "discord.js";
 
 export default interface EmbedParameters {
-    color: string;
-    title: string;
-    description: string | undefined;
-    fields: EmbedField[] | undefined;
-    author_text: string | undefined;
-    footer: string | undefined;
-    thumbnail_url: string | undefined;
-    image_url: string | undefined;
+    color?: string;
+    title?: string;
+    title_url?: string;
+    description?: string;
+    fields?: EmbedField[];
+    author_text?: string;
+    author_url?: string;
+    author_icon?: string;
+    footer_text?: string;
+    footer_icon?: string;
+    thumbnail_url?: string;
+    image_url?: string;
 }
 export function toAPIEmbed(parameters: EmbedParameters): APIEmbed {
-    let embed = new EmbedBuilder().setColor(parseInt("0x" + parameters.color.replaceAll("#", ""), 16)).setTitle(parameters.title).setDescription(parameters.description || null).setAuthor(parameters.author_text ? {
-        name: parameters.author_text
-    } : null).setFooter(parameters.footer ? {
-        text: parameters.footer
+    let embed = new EmbedBuilder().setColor(parameters.color && /(#|)[0-9a-fA-F]{6}/.test(parameters.color) ? parseInt("0x" + parameters.color.replaceAll("#", ""), 16) : null)
+    .setTitle(parameters.title || null)
+    .setURL(parameters.title_url || null)
+    .setDescription(parameters.description || null).setAuthor(parameters.author_text ? {
+        name: parameters.author_text,
+        url: parameters.author_url,
+        iconURL: parameters.author_icon,
+
+    } : null).setFooter(parameters.footer_text ? {
+        text: parameters.footer_text,
+        iconURL: parameters.footer_icon,
     } : null).toJSON();
     embed.fields = parameters.fields;
     embed.thumbnail = parameters.thumbnail_url ? {


### PR DESCRIPTION
optimized embed system, merged content to remove redundant "text" subcommand from multiple commands.. makes reaction roles easier. Added title URL for embed urls, author urls, icons for the Author and Footer, and a change to the way toAPIEmbed() is done to allow for embeds with no title... just throw an error if there's some weird error making the embed because of the way discord works xd